### PR TITLE
Fix server rack texture

### DIFF
--- a/computer/computers.lua
+++ b/computer/computers.lua
@@ -316,8 +316,8 @@ minetest.register_node("computer:server_on", {
 	tiles = {
 		'computer_server_t.png',
 		'computer_server_bt.png',
-		'computer_server_r.png',
 		'computer_server_l.png',
+		'computer_server_r.png',
 		'computer_server_bt.png',
 		'computer_server_f_on.png',
 	},


### PR DESCRIPTION
The left and right tiles were swapped when the server is turned on creating a gap between the back of the server and the sides. This resolves the issue.