### PR TITLE
Replace deprecated methods

### DIFF
--- a/homedecor/init.lua
+++ b/homedecor/init.lua
@@ -15,7 +15,7 @@ homedecor = {
 	modpath = modpath,
 
 	-- infinite stacks
-	expect_infinite_stacks = minetest.setting_getbool("creative_mode") and not minetest.get_modpath("unified_inventory")
+	expect_infinite_stacks = minetest.settings:get_bool("creative_mode") and not minetest.get_modpath("unified_inventory")
 }
 
 -- Determine if the item being pointed at is the underside of a node (e.g a ceiling)

--- a/lrfurn/armchairs.lua
+++ b/lrfurn/armchairs.lua
@@ -108,6 +108,6 @@ minetest.register_lbm({
 	end
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/armchairs] "..S("Loaded!"))
 end

--- a/lrfurn/coffeetable.lua
+++ b/lrfurn/coffeetable.lua
@@ -65,6 +65,6 @@ minetest.register_craft({
 	}
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/coffeetable] "..S("Loaded!"))
 end

--- a/lrfurn/endtable.lua
+++ b/lrfurn/endtable.lua
@@ -48,6 +48,6 @@ minetest.register_craft({
 	}
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/endtable] "..S("Loaded!"))
 end

--- a/lrfurn/longsofas.lua
+++ b/lrfurn/longsofas.lua
@@ -122,6 +122,6 @@ minetest.register_lbm({
 	end
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/longsofas] "..S("Loaded!"))
 end

--- a/lrfurn/sofas.lua
+++ b/lrfurn/sofas.lua
@@ -122,6 +122,6 @@ minetest.register_lbm({
 	end
 })
 
-if minetest.setting_get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "[lrfurn/sofas] "..S("Loaded!"))
 end


### PR DESCRIPTION
- 'setting_get' with 'settings:get'
- 'setting_getbool' with 'settings:get_bool'

May not want to merge this until after 0.4.16 release, as the new ['settings' object calls][l_settings] are not available in 0.4.15.

[l_settings]: https://github.com/minetest/minetest/blob/43d1f375d18a2fbc547a9b4f23d1354d645856ca/src/script/lua_api/l_settings.cpp#L267